### PR TITLE
added bound_correction_thresh to IndependentBounds

### DIFF
--- a/src/bounds.jl
+++ b/src/bounds.jl
@@ -6,6 +6,7 @@ bounds(t::Tuple, pomdp::POMDP, b::ScenarioBelief) = (lbound(t[1], pomdp, b), ubo
 function bounds_sanity_check(pomdp::POMDP, sb::ScenarioBelief, L_0, U_0)
     if L_0 > U_0
         @warn("L_0 ($L_0) > U_0 ($U_0)   |ϕ| = $(length(sb.scenarios))")
+        @info("Try e.g. `IndependentBounds(l, u, bound_correction_thresh=1e-5)`.", maxlog=1)
     end
     if all(isterminal(pomdp, s) for s in particles(sb))
         if L_0 != 0.0 || U_0 != 0.0
@@ -15,31 +16,46 @@ function bounds_sanity_check(pomdp::POMDP, sb::ScenarioBelief, L_0, U_0)
 end
 
 """
-    IndependentBounds(l, u, check_terminal=false)
+    IndependentBounds(l, u, check_terminal=false, bound_correction_thresh=0.0)
 
 Specify lower and upper bounds that are independent of each other (the most common case).
 
-This differs from specifying bounds as a `Tuple` because of the `check_terminal` option. If `check_terminal` is true, then if all the states in the belief are terminal, the upper and lower bounds will be overridden and set to 0.
+This differs from specifying bounds as a `Tuple` because of the keyword options.
+
+# Keyword Arguments
+- `check_terminal::Bool=false`: if true, then if all the states in the belief are terminal, the upper and lower bounds will be overridden and set to 0.
+- `bound_correction_thresh::Float64=0.0`: if `u < l` and `u >= l-bound_correction_thresh`, then `u` will be bumped up to `l`. 
 """
 struct IndependentBounds{L, U}
     lower::L
     upper::U
     check_terminal::Bool
+    bound_correction_thresh::Float64
 end
 
-IndependentBounds(l, u; check_terminal=false) = IndependentBounds(l, u, check_terminal)
+function IndependentBounds(l, u;
+                           check_terminal=false,
+                           bound_correction_thresh=0.0)
+    return IndependentBounds(l, u, check_terminal, bound_correction_thresh)
+end
 
 function bounds(bounds::IndependentBounds, pomdp::POMDP, b::ScenarioBelief)
     if bounds.check_terminal && all(isterminal(pomdp, s) for s in particles(b))
         return (0.0, 0.0)
     end
-    return (lbound(bounds.lower, pomdp, b), ubound(bounds.upper, pomdp, b))
+    l = lbound(bounds.lower, pomdp, b)
+    u = ubound(bounds.upper, pomdp, b)
+    if u < l && u >= l-bounds.bound_correction_thresh
+        u = l
+    end
+    return (l,u)
 end
 
 function init_bounds(bounds::IndependentBounds, pomdp::POMDP, sol::DESPOTSolver) 
     return IndependentBounds(init_bound(bounds.lower, pomdp, sol),
                              init_bound(bounds.upper, pomdp, sol),
-                             bounds.check_terminal
+                             bounds.check_terminal,
+                             bounds.bound_correction_thresh
                             )
 end
 init_bound(bound, pomdp, sol) = bound

--- a/src/bounds.jl
+++ b/src/bounds.jl
@@ -6,7 +6,7 @@ bounds(t::Tuple, pomdp::POMDP, b::ScenarioBelief) = (lbound(t[1], pomdp, b), ubo
 function bounds_sanity_check(pomdp::POMDP, sb::ScenarioBelief, L_0, U_0)
     if L_0 > U_0
         @warn("L_0 ($L_0) > U_0 ($U_0)   |ϕ| = $(length(sb.scenarios))")
-        @info("Try e.g. `IndependentBounds(l, u, correction_thresh=1e-5)`.", maxlog=1)
+        @info("Try e.g. `IndependentBounds(l, u, consistency_fix_thresh=1e-5)`.", maxlog=1)
     end
     if all(isterminal(pomdp, s) for s in particles(sb))
         if L_0 != 0.0 || U_0 != 0.0
@@ -22,7 +22,7 @@ function bounds_sanity_check(pomdp::POMDP, sb::ScenarioBelief, L_0, U_0)
 end
 
 """
-    IndependentBounds(l, u, check_terminal=false, correction_thresh=0.0)
+    IndependentBounds(l, u, check_terminal=false, consistency_fix_thresh=0.0)
 
 Specify lower and upper bounds that are independent of each other (the most common case).
 
@@ -30,19 +30,19 @@ This differs from specifying bounds as a `Tuple` because of the keyword options.
 
 # Keyword Arguments
 - `check_terminal::Bool=false`: if true, then if all the states in the belief are terminal, the upper and lower bounds will be overridden and set to 0.
-- `correction_thresh::Float64=0.0`: if `u < l` and `u >= l-correction_thresh`, then `u` will be bumped up to `l`. 
+- `consistency_fix_thresh::Float64=0.0`: if `u < l` and `u >= l-consistency_fix_thresh`, then `u` will be bumped up to `l`. 
 """
 struct IndependentBounds{L, U}
     lower::L
     upper::U
     check_terminal::Bool
-    correction_thresh::Float64
+    consistency_fix_thresh::Float64
 end
 
 function IndependentBounds(l, u;
                            check_terminal=false,
-                           correction_thresh=0.0)
-    return IndependentBounds(l, u, check_terminal, correction_thresh)
+                           consistency_fix_thresh=0.0)
+    return IndependentBounds(l, u, check_terminal, consistency_fix_thresh)
 end
 
 function bounds(bounds::IndependentBounds, pomdp::POMDP, b::ScenarioBelief)
@@ -51,7 +51,7 @@ function bounds(bounds::IndependentBounds, pomdp::POMDP, b::ScenarioBelief)
     end
     l = lbound(bounds.lower, pomdp, b)
     u = ubound(bounds.upper, pomdp, b)
-    if u < l && u >= l-bounds.correction_thresh
+    if u < l && u >= l-bounds.consistency_fix_thresh
         u = l
     end
     return (l,u)
@@ -61,7 +61,7 @@ function init_bounds(bounds::IndependentBounds, pomdp::POMDP, sol::DESPOTSolver)
     return IndependentBounds(init_bound(bounds.lower, pomdp, sol),
                              init_bound(bounds.upper, pomdp, sol),
                              bounds.check_terminal,
-                             bounds.correction_thresh
+                             bounds.consistency_fix_thresh
                             )
 end
 init_bound(bound, pomdp, sol) = bound

--- a/test/independent_bounds.jl
+++ b/test/independent_bounds.jl
@@ -1,0 +1,11 @@
+@testset "Independent Bounds" begin
+    m = BabyPOMDP()
+    rs = MemorizingSource(1,1)
+    sb = ScenarioBelief([1=>true], rs, 0, false)
+    b = IndependentBounds(0.0, -1e-5)
+    @test bounds(b, m, sb) == (0.0, -1e-5)
+    b = IndependentBounds(0.0, -1e-5, bound_correction_thresh=1e-5)
+    @test bounds(b, m, sb) == (0.0, 0.0)
+    b = IndependentBounds(0.0, -1e-4, bound_correction_thresh=1e-5)
+    @test bounds(b, m, sb) == (0.0, -1e-4)
+end

--- a/test/independent_bounds.jl
+++ b/test/independent_bounds.jl
@@ -4,8 +4,8 @@
     sb = ScenarioBelief([1=>true], rs, 0, false)
     b = IndependentBounds(0.0, -1e-5)
     @test bounds(b, m, sb) == (0.0, -1e-5)
-    b = IndependentBounds(0.0, -1e-5, bound_correction_thresh=1e-5)
+    b = IndependentBounds(0.0, -1e-5, consistency_fix_thresh=1e-5)
     @test bounds(b, m, sb) == (0.0, 0.0)
-    b = IndependentBounds(0.0, -1e-4, bound_correction_thresh=1e-5)
+    b = IndependentBounds(0.0, -1e-4, consistency_fix_thresh=1e-5)
     @test bounds(b, m, sb) == (0.0, -1e-4)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using POMDPModelTools
 using ParticleFilters
 
 include("memorizing_rng.jl")
+include("independent_bounds.jl")
 
 pomdp = BabyPOMDP()
 
@@ -49,15 +50,15 @@ sup = support(b)
 @test weight(b, 1) == 1.0
 
 # constant bounds
-bounds = (reward(pomdp, true, false)/(1-discount(pomdp)), 0.0)
-solver = DESPOTSolver(bounds=bounds)
+bds = (reward(pomdp, true, false)/(1-discount(pomdp)), 0.0)
+solver = DESPOTSolver(bounds=bds)
 planner = solve(solver, pomdp)
 hr = HistoryRecorder(max_steps=2)
 @time hist = simulate(hr, pomdp, planner)
 
 # policy lower bound
-bounds = IndependentBounds(DefaultPolicyLB(FeedWhenCrying()), 0.0)
-solver = DESPOTSolver(bounds=bounds)
+bds = IndependentBounds(DefaultPolicyLB(FeedWhenCrying()), 0.0)
+solver = DESPOTSolver(bounds=bds)
 planner = solve(solver, pomdp)
 hr = HistoryRecorder(max_steps=2)
 @time hist = simulate(hr, pomdp, planner)
@@ -65,9 +66,9 @@ hr = HistoryRecorder(max_steps=2)
 
 # Type stability 
 pomdp = BabyPOMDP()
-bounds = IndependentBounds(reward(pomdp, true, false)/(1-discount(pomdp)), 0.0)
+bds = IndependentBounds(reward(pomdp, true, false)/(1-discount(pomdp)), 0.0)
 solver = DESPOTSolver(epsilon_0=0.1,
-                      bounds=bounds,
+                      bounds=bds,
                       rng=MersenneTwister(4)
                      )
 p = solve(solver, pomdp)
@@ -85,10 +86,10 @@ D = @inferred ARDESPOT.build_despot(p, b0)
 @inferred action(p, b0)
 
 
-bounds = IndependentBounds(reward(pomdp, true, false)/(1-discount(pomdp)), 0.0)
+bds = IndependentBounds(reward(pomdp, true, false)/(1-discount(pomdp)), 0.0)
 rng = MersenneTwister(4)
 solver = DESPOTSolver(epsilon_0=0.1,
-                      bounds=bounds,
+                      bounds=bds,
                       rng=rng,
                       random_source=MemorizingSource(500, 90, rng),
                       tree_in_info=true
@@ -116,4 +117,3 @@ for (s, a, o) in stepthrough(pomdp, planner, "sao", max_steps=10)
     println("action $a was taken,")
     println("and observation $o was received.\n")
 end
-


### PR DESCRIPTION
I think this is the best way to deal with the annoying bounds warnings when the bounds only differ by numerically small amounts. Any comments?