### PR TITLE
CI Updates and removal of POMDPSimulators from tests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,0 @@
-comment: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
     tags: '*'
   pull_request:
 jobs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,4 +32,4 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3
         with:
-          file: lcov.info
+          files: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,16 +1,35 @@
 name: CI
-
-on: [push, pull_request]
-
+on:
+  push:
+    branches:
+      - main
+    tags: '*'
+  pull_request:
 jobs:
   test:
-    runs-on: ubuntu-latest
-
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1"
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
-          arch: x64
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v3
+        with:
+          file: lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+.vscode
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -26,8 +26,7 @@ julia = "1"
 
 [extras]
 POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
-POMDPSimulators = "e0d0a172-29c6-5d4e-96d0-f262df5d01fd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "POMDPSimulators", "POMDPModels"]
+test = ["Test", "POMDPModels"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ARDESPOT
 
 [![CI](https://github.com/JuliaPOMDP/ARDESPOT.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaPOMDP/ARDESPOT.jl/actions/workflows/CI.yml)
-[![Coverage Status](https://coveralls.io/repos/JuliaPOMDP/ARDESPOT.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaPOMDP/ARDESPOT.jl?branch=master)
 [![codecov.io](http://codecov.io/github/JuliaPOMDP/ARDESPOT.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaPOMDP/ARDESPOT.jl?branch=master)
 
 An implementation of the AR-DESPOT (Anytime Regularized DEterminized Sparse Partially Observable Tree) online POMDP Solver.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,6 @@ using Test
 
 using POMDPs
 using POMDPModels
-using POMDPSimulators
 using Random
 using POMDPTools
 using ParticleFilters


### PR DESCRIPTION
Updated the CI to run tests and publish the coverage. The last update on codecov was commit 269f495 (~4 years ago).

Updated .gitignore to include Manifest.toml and .vscode for vscode users.

Removed POMDPSimulators from the tests since it uses POMDPTools now.